### PR TITLE
Fixing onScroll null events

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -229,6 +229,7 @@ export default class AutoScrollFlatList<T> extends React.PureComponent<Props<T>,
                 onScroll(event);
             }
         });
+        event.persist();
     };
 
     private renderDefaultNewItemAlertComponent = (newItemCount: number, translateY: Animated.Value) => {


### PR DESCRIPTION
I'm trying to use the `FlatList` prop `onScroll` to determine when i reach the top of the list. Unfortunately, the event returned from the callback always has `nativeEvent` set to null.

I also get the below error in the console:
![Screen Shot 2020-02-05 at 6 23 58 PM](https://user-images.githubusercontent.com/10798072/73860898-f09cb800-4844-11ea-8a65-fc8704da7bb1.png)

Using `event.persist();` seems to fix this issue.